### PR TITLE
docs: publication semantics for consumers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,8 @@
 ## Interaction Style
 - Be extremely concise. Sacrifice grammar for the sake of concision.
 
+## Publications
+- `publicationId` semantics and consumer rules: see `docs/publications.md`. Only valid when `status` is `published`.
+
 ## Database Schema Changes
 - When changing Flyway migrations, persisted enums, JPA converters, views, or DB-facing entities, use the `refresh-database-schema-docs` skill and regenerate `docs/database-schema.md`.

--- a/docs/publications.md
+++ b/docs/publications.md
@@ -1,0 +1,47 @@
+# Publications
+
+A publication is the unit that makes a form definition publicly available. Each
+one gets a `publicationId`, a TypeId with prefix `pub`, e.g.
+`pub_01kzbh1czmevdah0yg3kebpk1s`.
+
+## What a publicationId identifies
+
+A publication ties together, at one point in time:
+
+- one form revision
+- the published form translations
+- the published global translations
+
+So `publicationId` identifies **everything needed to render that form**, which a
+form revision alone does not.
+
+## Consumer rules
+
+**Publishing global translations creates a new publication for all affected
+forms without changing any form revision.** A consumer that identifies rendered
+output by `revision` therefore under-identifies it: the same revision can render
+differently before and after a global translation publish. Use `publicationId`
+where the identity of rendered output matters.
+
+**`publicationId` is only valid when `status` is `published`.** Endpoints that
+return the current revision return the *latest* publication's `publicationId`
+even when that revision is a draft ahead of it (`status: pending`). The id then
+describes different components than the ones returned. Consumers must check
+`status` before trusting it:
+
+```
+status == "published" && publicationId != null
+```
+
+Fetching a specific published snapshot does not have this problem.
+
+**`publicationId` is opt-in via `select`.** Like other fields it is omitted
+unless requested, and omission is not an error — consumers see `null`, not a
+failure.
+
+## Backfill
+
+`publicationId` was introduced after many forms had already been published.
+Forms published before it exists have none; they acquire one on their next
+publication. Consumers must handle its absence on published forms, and coverage
+grows only as forms are republished.


### PR DESCRIPTION
Docs only. Adds `docs/publications.md` plus a pointer from `AGENTS.md`.

Written after a consumer (fyllut) design discussion surfaced two rules that are easy to get wrong and were not written down anywhere:

- **Publishing global translations creates a new publication for all affected forms without changing any form revision.** A consumer identifying rendered output by `revision` therefore under-identifies it.
- **`publicationId` is only valid when `status` is `published`.** Endpoints returning the current revision return the *latest* publication's id even when that revision is a draft ahead of it, so the id describes different components than the ones returned.

Also records that `publicationId` is opt-in via `select` (omission is not an error) and that forms published before the feature existed have none until republished.

Stacked on `docs/mise`, per branch base agreed with @akgagnat.